### PR TITLE
Update ironbox client compatible with python3

### DIFF
--- a/IronBoxCreateRemoveSFTContainer.py
+++ b/IronBoxCreateRemoveSFTContainer.py
@@ -42,19 +42,19 @@ def main():
     ContainerConfig.Description = "Description of the new container (optional)"
     ResultContainerConfig = IronBoxRESTObj.CreateEntitySFTContainer(Context, ContainerConfig)
     if ResultContainerConfig is None:
-	print "Unable to create container"
+	print("Unable to create container")
 	return
 
-    print "New container created with ID=%s" % ResultContainerConfig.ContainerID
+    print("New container created with ID=%s" % ResultContainerConfig.ContainerID)
 
     #--------------------------------------------------
     #	Remove the container
     #--------------------------------------------------
     if IronBoxRESTObj.RemoveEntityContainer(ResultContainerConfig.ContainerID) is False:
-	print "Unable to remove container"
+	print("Unable to remove container")
 	return
 
-    print "New container was successfully removed"	
+    print("New container was successfully removed")
 
 #---------------------------------------------------
 import string, datetime

--- a/IronBoxGetBlobInfoListByState.py
+++ b/IronBoxGetBlobInfoListByState.py
@@ -49,7 +49,7 @@ def main():
     # where 0 = blob ID and 1 = blob name 
     result = IronBoxRESTObj.GetContainerBlobInfoListByState(ContainerID, BlobState)
     for item in result:
-	print "%s -> %s" % (item[0],item[1]) 
+	print("%s -> %s" % (item[0],item[1]))
 
 #---------------------------------------------------
 if __name__ == "__main__":

--- a/IronBoxGetContextContainers.py
+++ b/IronBoxGetContextContainers.py
@@ -54,7 +54,7 @@ def main():
     # where 0 = blob ID and 1 = blob name
     result = IronBoxRESTObj.GetContainerInfoListByContext(Context, ContainerType)
     for item in result:
-        print "%s -> %s" % (item[0],item[1])
+        print("%s -> %s" % (item[0],item[1]))
 
 #---------------------------------------------------
 if __name__ == "__main__":

--- a/IronBoxGetContextSetting.py
+++ b/IronBoxGetContextSetting.py
@@ -40,8 +40,8 @@ def main():
     #---------------------------- 
     #	Get some public information about the context
     #---------------------------- 
-    print "Company Name: %s" % IronBoxRESTObj.GetContextSetting(Context, "CompanyName")
-    print "Company Logo URL: %s" % IronBoxRESTObj.GetContextSetting(Context, "CompanyLogoUrl")
+    print("Company Name: %s" % IronBoxRESTObj.GetContextSetting(Context, "CompanyName"))
+    print("Company Logo URL: %s" % IronBoxRESTObj.GetContextSetting(Context, "CompanyLogoUrl"))
 
 #---------------------------------------------------
 import string, datetime

--- a/IronBoxREST.py
+++ b/IronBoxREST.py
@@ -49,6 +49,7 @@ import sys
 import requests
 from Crypto.Cipher import AES
 import json
+import base64
 
 class IronBoxRESTClient():
 
@@ -330,7 +331,7 @@ class IronBoxRESTClient():
     def console_log(self, m):
 	if self.Verbose is True:
 	    now = datetime.datetime.now()
-	    print str(now) + ": " + m
+	    print(str(now) + ": " + m)
 
     #*************************************************************
     #	CORE REST API FUNCTIONS 
@@ -381,8 +382,8 @@ class IronBoxRESTClient():
         session_key_base_64 = response.get('SessionKeyBase64', None)
         if not session_key_base_64:
             return None
-        ContainerKeyData.SymmetricKey = session_key_base_64.decode('base64', 'strict')
-        ContainerKeyData.IV = response.get('SessionIVBase64').decode('base64', 'strict')
+        ContainerKeyData.SymmetricKey = base64.b64decode(session_key_base_64, validate=True)
+        ContainerKeyData.IV = base64.b64decode(response.get('SessionIVBase64'), validate=True)
         ContainerKeyData.KeyStrength =  response.get('SymmetricKeyStrength')
 
         return ContainerKeyData
@@ -802,7 +803,7 @@ class IronBoxKeyData():
 			outfile.write(e.encrypt(buf))
 	    return True
 
-	except Exception, e:
+	except Exception:
 	    return False
 
     #-------------------------------------------------------------
@@ -825,7 +826,7 @@ class IronBoxKeyData():
 			    decrypted = unpad(decrypted)
 			outfile.write(decrypted) 
 	    return True
-	except Exception, e:
+	except Exception:
 	    return False
 
 #------------------------------------------------------------------
@@ -841,12 +842,12 @@ class IronBoxBlobCheckOutData():
     ContainerStorageName = ""
 
     def DebugPrintProps(self):
-	print "SharedAccessSignature: %s" % self.SharedAccessSignature
-	print "SharedAccessSignatureUri: %s" % self.SharedAccessSignatureUri
-	print "CheckInToken: %s" % self.CheckInToken 
-	print "StorageUri: %s" % self.StorageUri 
-	print "StorageType: %d" % self.StorageType 
-	print "ContainerStorageName: %s" % self.ContainerStorageName 
+	print("SharedAccessSignature: %s" % self.SharedAccessSignature)
+	print("SharedAccessSignatureUri: %s" % self.SharedAccessSignatureUri)
+	print("CheckInToken: %s" % self.CheckInToken) 
+	print("StorageUri: %s" % self.StorageUri) 
+	print("StorageType: %d" % self.StorageType) 
+	print("ContainerStorageName: %s" % self.ContainerStorageName) 
 
 
 #------------------------------------------------------------------
@@ -861,11 +862,11 @@ class IronBoxBlobReadData():
     StorageUri = ""
 
     def DebugPrintProps(self):
-	print "ContainerStorageName: %s" % self.ContainerStorageName
-	print "SharedAccessSignature: %s" % self.SharedAccessSignature
-	print "SharedAccessSignatureUri: %s" % self.SharedAccessSignatureUri
-	print "StorageType: %s" % self.StorageType
-	print "StorageUri: %s" % self.StorageUri
+	print("ContainerStorageName: %s" % self.ContainerStorageName)
+	print("SharedAccessSignature: %s" % self.SharedAccessSignature)
+	print("SharedAccessSignatureUri: %s" % self.SharedAccessSignatureUri)
+	print("StorageType: %s" % self.StorageType)
+	print("StorageUri: %s" % self.StorageUri)
 
 #------------------------------------------------------------------
 #   Class to hold IronBox entity SFT container information
@@ -878,7 +879,7 @@ class IronBoxSFTContainerConfig():
     FriendlyID = ""
 
     def DebugPrintProps(self):
-	print "Name: %s" % self.Name
-	print "Description: %s" % self.Description
-	print "ContainerID: %d" % self.ContainerID
-	print "FriendlyID: %s" % self.FriendlyID
+	print("Name: %s" % self.Name)
+	print("Description: %s" % self.Description)
+	print("ContainerID: %d" % self.ContainerID)
+	print("FriendlyID: %s" % self.FriendlyID)


### PR DESCRIPTION
The following changes are made in this PR to make ironbox client compatible with python3

Converted all non-compatible print statements to python3 compatible print statements
Converted try/except blocks to be compatible with python3.
string to base64 and viceversa isnot supported in python3 and it is supported via base64 library. The encryptions key from ironbox are base64 encoded and we need to decode them to do the client side encryption